### PR TITLE
Configure GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM bash:5
+COPY entrypoint.sh /
+COPY problem-matcher.json /
+COPY splinter /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,16 @@
+name: 'Splinter'
+description: 'Simple pattern-based linter'
+inputs:
+  rules_file:
+    description: 'Rules file path'
+    required: true
+    default: '.splinter'
+  src_paths:
+    description: 'List of files/directories to lint'
+    required: false
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.rules_file }}
+    - ${{ inputs.src_paths }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cp /problem-matcher.json $HOME
+echo "::add-matcher::$HOME/problem-matcher.json"
+/splinter "$@"

--- a/problem-matcher.json
+++ b/problem-matcher.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "splinter",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(.+)$",
+          "file": 1,
+          "line": 2,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Thanks for this script!

I found this useful to do some simple YAML front matter linting and ended up wrapping it in a [GitHub Action](https://github.com/features/actions) which looks something like this to use:

```yaml
uses: namoscato/splinter@v1
with:
  rules_file: .splinter
  src_paths: src
```

This also registers a custom [problem matcher](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md) which creates GitHub check run annotations, i.e.

<img width="1004" alt="Screen Shot 2020-05-24 at 6 57 26 PM" src="https://user-images.githubusercontent.com/847532/82766992-ddacf400-9df1-11ea-982a-e6e37ed41493.png">

If this is something you are open to merging and/or adding to the marketplace, I am happy to help out with some more documentation.