### PR TITLE
Add support for an ignore line statement

### DIFF
--- a/splinter
+++ b/splinter
@@ -46,11 +46,16 @@ main() {
   local i
   for i in "${!regexes[@]}"; do
     local matches
-    matches="$(grep -EHInr "${regexes[$i]}" "${src_paths[@]}" || echo)"
+    local should_ignore
+    matches="$(grep -EHInr "${regexes[$i]}" "$PWD/${src_paths[@]}" || echo)"
+
     if [ -n "$matches" ]; then
-      violations+="$(
-        echo "$matches" | cut -d: -f-2 | sed "s#\$#:${messages[$i]}#g" \
-      )"$'\n'
+      while IFS= read -r match; do
+        if ! echo "$match" | grep -q "splinter:ignore"; then
+          violation=$(echo "$match" | cut -d: -f-2 | sed "s#\$#:${messages[$i]}#g")
+          violations+="$violation"$'\n'
+        fi
+      done < <(echo "$matches")
     fi
   done
 


### PR DESCRIPTION
This adds support to add a `splinter:ignore` somewhere in a line that has a violation that you want to ignore. 

It can be anywhere in the line, using any kind of comment strategy:

```swift
// Don't show a warning for this deprecated line
let size = CGFloat.standardSpacing_DEPRECATED // splinter:ignore
```

```python
# This method shouldn't be called, but splinter will ignore it.
thing = old_method_dont_use() # splinter:ignore
```