### PR TITLE
Update `duolingo` pre-commit hook to 1.15.0 (TOOLS-592)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/duolingo/pre-commit-hooks.git
-    rev: 1.8.0
+    rev: 1.15.0
     hooks:
       - id: duolingo


### PR DESCRIPTION
This yearly upgrade does the following and should be fairly safe:

- Updates all formatting tools to their latest versions
- Sorts TypeScript interface members automatically
- Adds native arm64 support
- Removes Python 2 support
- Hides autogenerated AI rule files in GitHub diffs by default

---

<details><summary>Click here to view the <a href="https://github.com/duolingo/pulldozer">Pulldozer</a> transformation script used to create this PR</summary>

```shell
#!/usr/bin/env sh

COMMIT_MESSAGE='Update `duolingo` pre-commit hook to 1.15.0 (TOOLS-592)'

transform() {
  replace_all '(repo: https://github.com/duolingo/pre-commit-hooks\.git.+rev: ).+(\n +hooks:\n +- id: duolingo)' '\11.15.0\2' '\.pre-commit-config\.yaml$'
  duo format || true
}

REPOS='
duolingo/pulldozer
duolingo/metasearch
duolingo/minject
duolingo/splinter
'

DESCRIPTION='This yearly upgrade does the following and should be fairly safe:

- Updates all formatting tools to their latest versions
- Sorts TypeScript interface members automatically
- Adds native arm64 support
- Removes Python 2 support
- Hides autogenerated AI rule files in GitHub diffs by default'
```